### PR TITLE
fixed config filepath construction to keep the root slash on linux

### DIFF
--- a/main/Config.js
+++ b/main/Config.js
@@ -53,9 +53,7 @@ class Config {
     //
     // }
 
-    const pathSplit = this._path.split(sep)
-    pathSplit.push(this._file)
-    this._filePath = join(...pathSplit)
+    this._filePath = join(this._path, this._file)
   }
 
   /**


### PR DESCRIPTION
In the constructor of the `Config` class in `Pulsar/main/Config.js`, we are creating the path to the config file.

When running on Linux, we have :

```js
this._path = join(homedir(), 'Pulsar') // => "/home/user/Pulsar"
```

But when constructing the full path to the config file, we are splitting by `sep` which is `/`. It's removing the first slash in the path : 

```js
const pathSplit = this._path.split(sep) // => ["", "home", "user", "Pulsar"]

pathSplit.push(this._file) // => ["", "home", "user", "Pulsar", ".pulsar.json"]

this._filePath = join(...pathSplit) // => "home/user/Pulsar/.pulsar.json"
```

Which leads to this error : https://github.com/lgeertsen/Pulsar/issues/9

So it's much simpler to join both the path to the `Pulsar` directory and the conf file : 

```js
this._filePath = join(this._path, this._file)
```
